### PR TITLE
Fix duplicate vaccine display logic

### DIFF
--- a/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
+++ b/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
@@ -181,29 +181,12 @@ export const RoundVaccinesForm: FunctionComponent<Props> = ({
         vaccines.length,
     ]);
 
-    // Add second vaccine row when adding a row over an empty first row
-    // Making this a separate effect to avoid disrupting the autofill of ReportDelays
+    // Add a vaccine if vaccines are empty
     useEffect(() => {
-        const currentVaccine = vaccines[0];
-        if (
-            vaccines.length === 1 &&
-            !currentVaccine.name &&
-            !currentVaccine.wastage_ratio_forecast &&
-            !currentVaccine.doses_per_vial &&
-            !HcDelay && // checking if ReportDelay has been autofilled to avoid recreating deleted vaccine row
-            !DistrictDelay &&
-            !RegionDelay
-        ) {
-            setFieldValue(`rounds[${roundIndex}].vaccines`, [...vaccines, {}]);
+        if (!vaccines || vaccines.length === 0) {
+            setFieldValue(`rounds[${roundIndex}].vaccines`, [{}]);
         }
-    }, [
-        DistrictDelay,
-        HcDelay,
-        RegionDelay,
-        roundIndex,
-        setFieldValue,
-        vaccines,
-    ]);
+    }, [roundIndex, setFieldValue, vaccines]);
 
     return (
         <>
@@ -219,15 +202,6 @@ export const RoundVaccinesForm: FunctionComponent<Props> = ({
                         />
                     );
                 })}
-            {/* if the condition is on length === 0 the UI will flicker and the field lose focus because of re-render */}
-            {vaccines.length <= 1 && (
-                <RoundVaccineForm
-                    vaccineIndex={0}
-                    roundIndex={roundIndex}
-                    vaccineOptions={polioVaccines}
-                />
-            )}
-
             <Grid
                 container
                 item


### PR DESCRIPTION
Explain what problem this PR is resolving

This PR resolves an issue where the "vaccines tab" was displaying duplicate rows for a single vaccine entry. The form logic in `RoundVaccinesForm.tsx` was causing two form rows to render even when only one vaccine was present, leading to redundant data display.

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

The changes were made in `plugins/polio/js/src/forms/RoundVaccinesForm.tsx`:

-   **Removed redundant rendering logic**: The conditional block that rendered a `RoundVaccineForm` when `vaccines.length <= 1` was removed. This was the primary cause of the duplicate row when only one vaccine existed.
-   **Refactored `useEffect` hook**: The `useEffect` hook responsible for initializing vaccine forms was simplified. It now ensures that an empty vaccine row is added only when the `vaccines` array is completely empty, preventing the form from being blank initially without creating duplicates.

## How to test

1.  Navigate to the "vaccines tab" in the Polio module.
2.  **Scenario 1 (No vaccines):** Ensure that if there are no vaccines, one empty vaccine form row is displayed.
3.  **Scenario 2 (One vaccine):** Add a single vaccine and verify that only one form row is displayed for that vaccine.
4.  **Scenario 3 (Multiple vaccines):** Add multiple vaccines and confirm that each vaccine corresponds to a single, unique form row.

## Print screen / video

[Please add print screens or videos here showing the corrected behavior]

## Notes

None.

---
<a href="https://cursor.com/background-agent?bcId=bc-6011b076-cb04-436a-beba-2735c6b8db44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6011b076-cb04-436a-beba-2735c6b8db44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

